### PR TITLE
Make UtcDateTime store ticks

### DIFF
--- a/src/UtcDateTime.cs
+++ b/src/UtcDateTime.cs
@@ -16,6 +16,8 @@ namespace Chronology
             this.value = value.ToUniversalTime();
         }
 
+        public long Ticks => value.Ticks;
+
         public UtcDateTime Add(TimeSpan value) => this + value;
         public int CompareTo(UtcDateTime other) => value < other.value ? -1 : value > other.value ? 1 : 0;
         public override bool Equals(object obj) => obj is UtcDateTime other ? Equals(other) : false;

--- a/src/UtcDateTime.cs
+++ b/src/UtcDateTime.cs
@@ -8,7 +8,11 @@ namespace Chronology
         readonly long ticks;
         #pragma warning restore IDE0032
 
-        public UtcDateTime(long ticks) => this.ticks = ticks;
+        public UtcDateTime(long ticks) {
+            if(ticks < 0 || ticks > DateTime.MaxValue.Ticks)
+                throw new ArgumentOutOfRangeException(nameof(ticks));
+            this.ticks = ticks;
+        }
 
         public UtcDateTime(DateTimeOffset value) => ticks = value.UtcDateTime.Ticks;
 

--- a/src/UtcDateTime.cs
+++ b/src/UtcDateTime.cs
@@ -4,41 +4,45 @@ namespace Chronology
 {
     public struct UtcDateTime: IEquatable<UtcDateTime>, IComparable<UtcDateTime>
     {
-        readonly DateTime value;
+        #pragma warning disable IDE0032 // Don't use auto-property; access read-only field for maximum performance.
+        readonly long ticks;
+        #pragma warning restore IDE0032
 
-        public UtcDateTime(long ticks) => value = new DateTime(ticks, DateTimeKind.Utc);
+        public UtcDateTime(long ticks) => this.ticks = ticks;
 
-        public UtcDateTime(DateTimeOffset value) => this.value = value.UtcDateTime;
+        public UtcDateTime(DateTimeOffset value) => ticks = value.UtcDateTime.Ticks;
 
         public UtcDateTime(DateTime value) {
             if(value.Kind != DateTimeKind.Utc)
                 throw new ArgumentException($"{nameof(DateTimeKind)}.{value.Kind} is not supported.", nameof(value));
-            this.value = value.ToUniversalTime();
+            ticks = value.ToUniversalTime().Ticks;
         }
 
-        public long Ticks => value.Ticks;
+        public long Ticks => ticks;
 
         public UtcDateTime Add(TimeSpan value) => this + value;
-        public int CompareTo(UtcDateTime other) => value < other.value ? -1 : value > other.value ? 1 : 0;
+        public int CompareTo(UtcDateTime other) => ticks < other.ticks ? -1 : ticks > other.ticks ? 1 : 0;
         public override bool Equals(object obj) => obj is UtcDateTime other ? Equals(other) : false;
-        public bool Equals(UtcDateTime other) => value.Equals(other.value);
-        public override int GetHashCode() => value.GetHashCode();
+        public bool Equals(UtcDateTime other) => ticks.Equals(other.ticks);
+        public override int GetHashCode() => ticks.GetHashCode();
         public UtcDateTime Subtract(TimeSpan value) => this - value;
         public TimeSpan Subtract(UtcDateTime value) => this - value;
         public DateTime ToDateTime() => this;
         public DateTimeOffset ToDateTimeOffset() => this;
         public override string ToString() => ToDateTime().ToString("o");
 
-        public static implicit operator DateTime(UtcDateTime utc) => utc.value.Kind == DateTimeKind.Utc ? utc.value : new DateTime(0, DateTimeKind.Utc);
-        public static implicit operator DateTimeOffset(UtcDateTime utc) => utc.value.Kind == DateTimeKind.Utc ? utc.value : new DateTimeOffset(0, TimeSpan.Zero);
-        public static bool operator ==(UtcDateTime left, UtcDateTime right) => left.value == right.value;
-        public static bool operator !=(UtcDateTime left, UtcDateTime right) => left.value != right.value;
-        public static UtcDateTime operator +(UtcDateTime left, TimeSpan right) => new UtcDateTime(left.value + right);
-        public static UtcDateTime operator -(UtcDateTime left, TimeSpan right) => new UtcDateTime(left.value - right);
-        public static TimeSpan operator -(UtcDateTime left, UtcDateTime right) => left.value - right.value;
-        public static bool operator <(UtcDateTime left, UtcDateTime right) => left.value < right.value;
-        public static bool operator <=(UtcDateTime left, UtcDateTime right) => left.value <= right.value;
-        public static bool operator >(UtcDateTime left, UtcDateTime right) => left.value > right.value;
-        public static bool operator >=(UtcDateTime left, UtcDateTime right) => left.value >= right.value;
+        public static implicit operator DateTime(UtcDateTime utc) => new DateTime(utc.ticks, DateTimeKind.Utc);
+        public static implicit operator DateTimeOffset(UtcDateTime utc) => new DateTimeOffset(utc.ticks, TimeSpan.Zero);
+
+        public static bool operator ==(UtcDateTime left, UtcDateTime right) => left.ticks == right.ticks;
+        public static bool operator !=(UtcDateTime left, UtcDateTime right) => left.ticks != right.ticks;
+        public static bool operator <(UtcDateTime left, UtcDateTime right) => left.ticks < right.ticks;
+        public static bool operator <=(UtcDateTime left, UtcDateTime right) => left.ticks <= right.ticks;
+        public static bool operator >(UtcDateTime left, UtcDateTime right) => left.ticks > right.ticks;
+        public static bool operator >=(UtcDateTime left, UtcDateTime right) => left.ticks >= right.ticks;
+
+        public static UtcDateTime operator +(UtcDateTime left, TimeSpan right) => new UtcDateTime(left.ticks + right.Ticks);
+        public static UtcDateTime operator -(UtcDateTime left, TimeSpan right) => new UtcDateTime(left.ticks - right.Ticks);
+        public static TimeSpan operator -(UtcDateTime left, UtcDateTime right) => new TimeSpan(left.ticks - right.ticks);
     }
 }

--- a/src/UtcDateTime.cs
+++ b/src/UtcDateTime.cs
@@ -7,7 +7,8 @@ namespace Chronology
         static readonly long minTicks = DateTime.MinValue.Ticks;
         static readonly long maxTicks = DateTime.MaxValue.Ticks;
 
-        #pragma warning disable IDE0032 // Don't use auto-property; access read-only field for maximum performance.
+        // Don't use auto-property; access field for maximum performance.
+        #pragma warning disable IDE0032
         readonly long ticks;
         #pragma warning restore IDE0032
 
@@ -28,26 +29,63 @@ namespace Chronology
 
         public long Ticks => ticks;
 
-        public UtcDateTime Add(TimeSpan timeSpan) => this + timeSpan;
-        public int CompareTo(UtcDateTime other) => ticks < other.ticks ? -1 : ticks > other.ticks ? 1 : 0;
-        public override bool Equals(object obj) => obj is UtcDateTime other ? Equals(other) : false;
-        public bool Equals(UtcDateTime other) => ticks.Equals(other.ticks);
-        public override int GetHashCode() => ticks.GetHashCode();
-        public UtcDateTime Subtract(TimeSpan timeSpan) => this - timeSpan;
-        public TimeSpan Subtract(UtcDateTime value) => this - value;
-        public DateTime ToDateTime() => this;
-        public DateTimeOffset ToDateTimeOffset() => this;
-        public override string ToString() => ToDateTime().ToString("o");
+        public UtcDateTime Add(TimeSpan timeSpan) =>
+            this + timeSpan;
 
-        public static implicit operator DateTime(UtcDateTime utc) => new DateTime(utc.ticks, DateTimeKind.Utc);
-        public static implicit operator DateTimeOffset(UtcDateTime utc) => new DateTimeOffset(utc.ticks, TimeSpan.Zero);
+        public int CompareTo(UtcDateTime other) =>
+            ticks < other.ticks ? -1 :
+            ticks > other.ticks ? 1 :
+            0;
 
-        public static bool operator ==(UtcDateTime left, UtcDateTime right) => left.ticks == right.ticks;
-        public static bool operator !=(UtcDateTime left, UtcDateTime right) => left.ticks != right.ticks;
-        public static bool operator <(UtcDateTime left, UtcDateTime right) => left.ticks < right.ticks;
-        public static bool operator <=(UtcDateTime left, UtcDateTime right) => left.ticks <= right.ticks;
-        public static bool operator >(UtcDateTime left, UtcDateTime right) => left.ticks > right.ticks;
-        public static bool operator >=(UtcDateTime left, UtcDateTime right) => left.ticks >= right.ticks;
+        public override bool Equals(object obj) =>
+            obj is UtcDateTime other
+            ? Equals(other)
+            : false;
+
+        public bool Equals(UtcDateTime other) =>
+            ticks.Equals(other.ticks);
+
+        public override int GetHashCode() =>
+            ticks.GetHashCode();
+
+        public UtcDateTime Subtract(TimeSpan timeSpan) =>
+            this - timeSpan;
+
+        public TimeSpan Subtract(UtcDateTime value) =>
+            this - value;
+
+        public DateTime ToDateTime() =>
+            this;
+
+        public DateTimeOffset ToDateTimeOffset() =>
+            this;
+
+        public override string ToString() =>
+            ToDateTime().ToString("o");
+
+        public static implicit operator DateTime(UtcDateTime utc) =>
+            new DateTime(utc.ticks, DateTimeKind.Utc);
+
+        public static implicit operator DateTimeOffset(UtcDateTime utc) =>
+            new DateTimeOffset(utc.ticks, TimeSpan.Zero);
+
+        public static bool operator ==(UtcDateTime left, UtcDateTime right) =>
+            left.ticks == right.ticks;
+
+        public static bool operator !=(UtcDateTime left, UtcDateTime right) =>
+            left.ticks != right.ticks;
+
+        public static bool operator <(UtcDateTime left, UtcDateTime right) =>
+            left.ticks < right.ticks;
+
+        public static bool operator <=(UtcDateTime left, UtcDateTime right) =>
+            left.ticks <= right.ticks;
+
+        public static bool operator >(UtcDateTime left, UtcDateTime right) =>
+            left.ticks > right.ticks;
+
+        public static bool operator >=(UtcDateTime left, UtcDateTime right) =>
+            left.ticks >= right.ticks;
 
         public static UtcDateTime operator +(UtcDateTime utc, TimeSpan timeSpan) =>
             timeSpan.Ticks < -utc.ticks || timeSpan.Ticks > maxTicks - utc.ticks
@@ -59,6 +97,7 @@ namespace Chronology
             ? throw new ArgumentOutOfRangeException(nameof(timeSpan))
             : new UtcDateTime(utc.ticks - timeSpan.Ticks);
 
-        public static TimeSpan operator -(UtcDateTime left, UtcDateTime right) => new TimeSpan(left.ticks - right.ticks);
+        public static TimeSpan operator -(UtcDateTime left, UtcDateTime right) =>
+            new TimeSpan(left.ticks - right.ticks);
     }
 }

--- a/src/UtcDateTime.cs
+++ b/src/UtcDateTime.cs
@@ -6,6 +6,8 @@ namespace Chronology
     {
         readonly DateTime value;
 
+        public UtcDateTime(long ticks) => value = new DateTime(ticks, DateTimeKind.Utc);
+
         public UtcDateTime(DateTimeOffset value) => this.value = value.UtcDateTime;
 
         public UtcDateTime(DateTime value) {
@@ -23,10 +25,10 @@ namespace Chronology
         public TimeSpan Subtract(UtcDateTime value) => this - value;
         public DateTime ToDateTime() => this;
         public DateTimeOffset ToDateTimeOffset() => this;
-        public override string ToString() => value.ToString("o");
+        public override string ToString() => ToDateTime().ToString("o");
 
-        public static implicit operator DateTime(UtcDateTime utc) => utc.value;
-        public static implicit operator DateTimeOffset(UtcDateTime utc) => utc.value;
+        public static implicit operator DateTime(UtcDateTime utc) => utc.value.Kind == DateTimeKind.Utc ? utc.value : new DateTime(0, DateTimeKind.Utc);
+        public static implicit operator DateTimeOffset(UtcDateTime utc) => utc.value.Kind == DateTimeKind.Utc ? utc.value : new DateTimeOffset(0, TimeSpan.Zero);
         public static bool operator ==(UtcDateTime left, UtcDateTime right) => left.value == right.value;
         public static bool operator !=(UtcDateTime left, UtcDateTime right) => left.value != right.value;
         public static UtcDateTime operator +(UtcDateTime left, TimeSpan right) => new UtcDateTime(left.value + right);

--- a/tests/ClockTest.cs
+++ b/tests/ClockTest.cs
@@ -7,13 +7,15 @@ namespace Chronology
     {
         readonly IClock sut = new Clock();
 
+        static readonly TimeSpan clockPrecision = TimeSpan.FromMilliseconds(16);
+
         public class Time: ClockTest
         {
             [Fact]
             public void ReturnsCurrentUtcDateTime() {
                 DateTime expected = DateTime.UtcNow;
                 UtcDateTime actual = sut.Time;
-                Assert.Equal(expected, actual, TimeSpan.FromMilliseconds(1));
+                Assert.Equal(expected, actual, clockPrecision);
             }
         }
     }

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fuzzy" Version="*" />
-    <PackageReference Include="Inspector" Version="*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />

--- a/tests/UtcDateTimeTest.cs
+++ b/tests/UtcDateTimeTest.cs
@@ -21,6 +21,14 @@ namespace Chronology
                 var sut = new UtcDateTime(input.Ticks);
                 Assert.Equal(input.Ticks, sut.Ticks);
             }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenInputIsLessThanZero() =>
+                Assert.Throws<ArgumentOutOfRangeException>(() => new UtcDateTime(-1));
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenInputIsGreaterThanMax() =>
+                Assert.Throws<ArgumentOutOfRangeException>(() => new UtcDateTime(DateTime.MaxValue.Ticks + 1));
         }
 
         public sealed class DateTimeOffsetConstructor: UtcDateTimeTest

--- a/tests/UtcDateTimeTest.cs
+++ b/tests/UtcDateTimeTest.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Fuzzy;
-using Inspector;
 using Xunit;
 
 namespace Chronology
 {
     public abstract class UtcDateTimeTest: TestFixture
     {
-        readonly UtcDateTime sut = new UtcDateTime(fuzzy.DateTimeOffset());
+        readonly UtcDateTime sut;
+
+        readonly DateTime inputDateTime = fuzzy.DateTime(DateTimeKind.Utc);
+
+        protected UtcDateTimeTest() => sut = new UtcDateTime(inputDateTime);
 
         public sealed class TicksConstructor: UtcDateTimeTest
         {
@@ -16,8 +19,7 @@ namespace Chronology
             public void CreatesValueFromLong() {
                 DateTime input = fuzzy.DateTime(DateTimeKind.Utc);
                 var sut = new UtcDateTime(input.Ticks);
-                Assert.Equal(input, sut.Field<DateTime>());
-                Assert.Equal(DateTimeKind.Utc, sut.Field<DateTime>().Value.Kind);
+                Assert.Equal(input.Ticks, sut.Ticks);
             }
         }
 
@@ -27,8 +29,7 @@ namespace Chronology
             public void CreatesValueFromDateTimeOffset() {
                 DateTimeOffset input = fuzzy.DateTimeOffset();
                 var sut = new UtcDateTime(input);
-                Assert.Equal(input.UtcDateTime, sut.Field<DateTime>());
-                Assert.Equal(DateTimeKind.Utc, sut.Field<DateTime>().Value.Kind);
+                Assert.Equal(input.UtcDateTime.Ticks, sut.Ticks);
             }
         }
 
@@ -38,8 +39,7 @@ namespace Chronology
             public void CreatesValueFromDateTimeWithUtcKind() {
                 DateTime input = fuzzy.DateTime(DateTimeKind.Utc);
                 var sut = new UtcDateTime(input);
-                Assert.Equal(input, sut.Field<DateTime>());
-                Assert.Equal(DateTimeKind.Utc, sut.Field<DateTime>().Value.Kind);
+                Assert.Equal(input.Ticks, sut.Ticks);
             }
 
             [Theory, InlineData(DateTimeKind.Local), InlineData(DateTimeKind.Unspecified)]
@@ -56,7 +56,7 @@ namespace Chronology
             [Fact]
             public void ConvertsInitializedValue() {
                 DateTime actual = sut;
-                Assert.Equal(sut.Field<DateTime>(), actual);
+                Assert.Equal(sut.Ticks, actual.Ticks);
                 Assert.Equal(DateTimeKind.Utc, actual.Kind);
             }
 
@@ -73,7 +73,7 @@ namespace Chronology
             [Fact]
             public void ConvertsInitializedValue() {
                 DateTimeOffset actual = sut;
-                Assert.Equal(sut.Field<DateTime>(), actual.DateTime);
+                Assert.Equal(sut.Ticks, actual.Ticks);
                 Assert.Equal(TimeSpan.Zero, actual.Offset);
             }
 
@@ -168,9 +168,9 @@ namespace Chronology
             [Fact]
             public void AddsTimeSpanToUtcDateTime() {
                 TimeSpan timeSpan = fuzzy.TimeSpan().Between(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
-                DateTime expected = sut.Field<DateTime>().Value + timeSpan;
+                DateTime expected = inputDateTime + timeSpan;
                 UtcDateTime actual = sut.Add(timeSpan);
-                Assert.Equal(expected, actual.Field<DateTime>());
+                Assert.Equal(expected.Ticks, actual.Ticks);
             }
         }
 
@@ -179,9 +179,9 @@ namespace Chronology
             [Fact]
             public void AddsTimeSpanToUtcDateTime() {
                 TimeSpan timeSpan = fuzzy.TimeSpan().Between(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
-                DateTime expected = sut.Field<DateTime>().Value + timeSpan;
+                DateTime expected = inputDateTime + timeSpan;
                 UtcDateTime actual = sut + timeSpan;
-                Assert.Equal(expected, actual.Field<DateTime>());
+                Assert.Equal(expected.Ticks, actual.Ticks);
             }
         }
 
@@ -246,10 +246,8 @@ namespace Chronology
         public new class GetHashCode: UtcDateTimeTest
         {
             [Fact]
-            public void ReturnsHashCodeOfDateTimeValue() {
-                DateTime expected = sut.Field<DateTime>();
-                Assert.Equal(expected.GetHashCode(), sut.GetHashCode());
-            }
+            public void ReturnsHashCodeOfDateTimeValue() =>
+                Assert.Equal(inputDateTime.GetHashCode(), sut.GetHashCode());
         }
 
         public class GreaterThanOperator: UtcDateTimeTest
@@ -353,15 +351,15 @@ namespace Chronology
             [Fact]
             public void SubtractsTimeSpanFromUtcDateTime() {
                 TimeSpan timeSpan = fuzzy.TimeSpan().Between(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
-                DateTime expected = sut.Field<DateTime>().Value - timeSpan;
+                DateTime expected = inputDateTime - timeSpan;
                 UtcDateTime actual = sut.Subtract(timeSpan);
-                Assert.Equal(expected, actual.Field<DateTime>());
+                Assert.Equal(expected.Ticks, actual.Ticks);
             }
 
             [Fact]
             public void SubtractsUtcDateTimeAndReturnsTimeSpan() {
                 DateTime other = fuzzy.DateTime(DateTimeKind.Utc);
-                TimeSpan expected = sut.Field<DateTime>().Value - other;
+                TimeSpan expected = inputDateTime - other;
                 TimeSpan actual = sut.Subtract(new UtcDateTime(other));
                 Assert.Equal(expected, actual);
             }
@@ -372,15 +370,15 @@ namespace Chronology
             [Fact]
             public void SubtractsTimeSpanFromUtcDateTime() {
                 TimeSpan timeSpan = fuzzy.TimeSpan().Between(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
-                DateTime expected = sut.Field<DateTime>().Value - timeSpan;
+                DateTime expected = inputDateTime - timeSpan;
                 UtcDateTime actual = sut - timeSpan;
-                Assert.Equal(expected, actual.Field<DateTime>());
+                Assert.Equal(expected.Ticks, actual.Ticks);
             }
 
             [Fact]
             public void SubtractsUtcDateTimeAndReturnsTimeSpan() {
                 DateTime other = fuzzy.DateTime(DateTimeKind.Utc);
-                TimeSpan expected = sut.Field<DateTime>().Value - other;
+                TimeSpan expected = inputDateTime - other;
                 TimeSpan actual = sut - new UtcDateTime(other);
                 Assert.Equal(expected, actual);
             }
@@ -390,8 +388,9 @@ namespace Chronology
         {
             [Fact]
             public void ConvertsInitializedValue() {
-                DateTime expected = sut.Field<DateTime>();
-                Assert.Equal(expected, sut.ToDateTime());
+                DateTime actual = sut.ToDateTime();
+                Assert.Equal(inputDateTime.Ticks, actual.Ticks);
+                Assert.Equal(DateTimeKind.Utc, actual.Kind);
             }
 
             [Fact]
@@ -406,8 +405,9 @@ namespace Chronology
         {
             [Fact]
             public void ConvertsInitializedValue() {
-                var expected = new DateTimeOffset(sut.Field<DateTime>());
-                Assert.Equal(expected, sut.ToDateTimeOffset());
+                DateTimeOffset actual = sut.ToDateTimeOffset();
+                Assert.Equal(inputDateTime.Ticks, actual.Ticks);
+                Assert.Equal(TimeSpan.Zero, actual.Offset);
             }
 
             [Fact]
@@ -422,7 +422,7 @@ namespace Chronology
         {
             [Fact]
             public void ReturnsValueInRoundTripFormat() {
-                string expected = sut.Field<DateTime>().Value.ToString("o");
+                string expected = inputDateTime.ToString("o");
                 string? actual = sut.ToString();
                 Assert.Equal(expected, actual);
             }

--- a/tests/UtcDateTimeTest.cs
+++ b/tests/UtcDateTimeTest.cs
@@ -10,20 +10,36 @@ namespace Chronology
     {
         readonly UtcDateTime sut = new UtcDateTime(fuzzy.DateTimeOffset());
 
-        public sealed class Constructor: UtcDateTimeTest
+        public sealed class TicksConstructor: UtcDateTimeTest
+        {
+            [Fact]
+            public void CreatesValueFromLong() {
+                DateTime input = fuzzy.DateTime(DateTimeKind.Utc);
+                var sut = new UtcDateTime(input.Ticks);
+                Assert.Equal(input, sut.Field<DateTime>());
+                Assert.Equal(DateTimeKind.Utc, sut.Field<DateTime>().Value.Kind);
+            }
+        }
+
+        public sealed class DateTimeOffsetConstructor: UtcDateTimeTest
         {
             [Fact]
             public void CreatesValueFromDateTimeOffset() {
                 DateTimeOffset input = fuzzy.DateTimeOffset();
                 var sut = new UtcDateTime(input);
                 Assert.Equal(input.UtcDateTime, sut.Field<DateTime>());
+                Assert.Equal(DateTimeKind.Utc, sut.Field<DateTime>().Value.Kind);
             }
+        }
 
+        public sealed class DateTimeConstructor: UtcDateTimeTest
+        {
             [Fact]
             public void CreatesValueFromDateTimeWithUtcKind() {
                 DateTime input = fuzzy.DateTime(DateTimeKind.Utc);
                 var sut = new UtcDateTime(input);
                 Assert.Equal(input, sut.Field<DateTime>());
+                Assert.Equal(DateTimeKind.Utc, sut.Field<DateTime>().Value.Kind);
             }
 
             [Theory, InlineData(DateTimeKind.Local), InlineData(DateTimeKind.Unspecified)]
@@ -35,19 +51,37 @@ namespace Chronology
             }
         }
 
-        public sealed class ImplicitConversionOperator: UtcDateTimeTest
+        public sealed class DateTimeConversionOperator: UtcDateTimeTest
         {
             [Fact]
-            public void ConvertsToDateTime() {
+            public void ConvertsInitializedValue() {
                 DateTime actual = sut;
                 Assert.Equal(sut.Field<DateTime>(), actual);
+                Assert.Equal(DateTimeKind.Utc, actual.Kind);
             }
 
             [Fact]
-            public void ConvertsToDateTimeOffset() {
+            public void ConvertsUninitializedValue() {
+                DateTime actual = default(UtcDateTime);
+                Assert.Equal(0, actual.Ticks);
+                Assert.Equal(DateTimeKind.Utc, actual.Kind);
+            }
+        }
+
+        public sealed class DateTimeOffsetComversionOperator: UtcDateTimeTest
+        {
+            [Fact]
+            public void ConvertsInitializedValue() {
                 DateTimeOffset actual = sut;
-                Assert.Equal(TimeSpan.Zero, actual.Offset);
                 Assert.Equal(sut.Field<DateTime>(), actual.DateTime);
+                Assert.Equal(TimeSpan.Zero, actual.Offset);
+            }
+
+            [Fact]
+            public void ConvertsUninitializedValue() {
+                DateTimeOffset actual = default(UtcDateTime);
+                Assert.Equal(0, actual.Ticks);
+                Assert.Equal(TimeSpan.Zero, actual.Offset);
             }
         }
 
@@ -61,8 +95,16 @@ namespace Chronology
             }
 
             [Fact]
+            public void ReturnsTrueWhenIninitializedIsEqualToDefault() {
+                var initialized = new UtcDateTime(0);
+                var uninitialized = default(UtcDateTime);
+                Assert.True(initialized == uninitialized);
+                Assert.True(uninitialized == initialized);
+            }
+
+            [Fact]
             public void ReturnsFalseWhenValuesAreDifferent() {
-                UtcDateTime other = new UtcDateTime(fuzzy.DateTimeOffset());
+                UtcDateTime other = new UtcDateTime(fuzzy.DateTime(DateTimeKind.Utc));
                 Assert.False(sut == other);
                 Assert.False(other == sut);
             }
@@ -96,6 +138,14 @@ namespace Chronology
                 UtcDateTime other = sut;
                 Assert.False(sut != other);
                 Assert.False(other != sut);
+            }
+
+            [Fact]
+            public void ReturnsFalseWhenOneInitializedValueIsEqualToDefault() {
+                var initialized = new UtcDateTime(0);
+                var uninitialized = default(UtcDateTime);
+                Assert.False(initialized != uninitialized);
+                Assert.False(uninitialized != initialized);
             }
 
             [Fact]
@@ -250,7 +300,6 @@ namespace Chronology
             }
         }
 
-
         public class LessThanOperator: UtcDateTimeTest
         {
             [Fact]
@@ -340,18 +389,32 @@ namespace Chronology
         public class ToDateTime: UtcDateTimeTest
         {
             [Fact]
-            public void ReturnsDateTimeValue() {
+            public void ConvertsInitializedValue() {
                 DateTime expected = sut.Field<DateTime>();
                 Assert.Equal(expected, sut.ToDateTime());
+            }
+
+            [Fact]
+            public void ConvertsUninitializedValue() {
+                DateTime actual = default(UtcDateTime).ToDateTime();
+                Assert.Equal(0, actual.Ticks);
+                Assert.Equal(DateTimeKind.Utc, actual.Kind);
             }
         }
 
         public class ToDateTimeOffset: UtcDateTimeTest
         {
             [Fact]
-            public void ReturnsDateTimeOffsetValue() {
+            public void ConvertsInitializedValue() {
                 var expected = new DateTimeOffset(sut.Field<DateTime>());
                 Assert.Equal(expected, sut.ToDateTimeOffset());
+            }
+
+            [Fact]
+            public void ConvertsUninitializedValue() {
+                DateTimeOffset actual = default(UtcDateTime).ToDateTimeOffset();
+                Assert.Equal(0, actual.Ticks);
+                Assert.Equal(TimeSpan.Zero, actual.Offset);
             }
         }
 
@@ -361,6 +424,13 @@ namespace Chronology
             public void ReturnsValueInRoundTripFormat() {
                 string expected = sut.Field<DateTime>().Value.ToString("o");
                 string? actual = sut.ToString();
+                Assert.Equal(expected, actual);
+            }
+
+            [Fact]
+            public void ConvertsUninitializedValueToUtc() {
+                string expected = new DateTime(0, DateTimeKind.Utc).ToString("o");
+                string? actual = default(UtcDateTime).ToString();
                 Assert.Equal(expected, actual);
             }
         }

--- a/tests/UtcDateTimeTest.cs
+++ b/tests/UtcDateTimeTest.cs
@@ -180,6 +180,20 @@ namespace Chronology
                 UtcDateTime actual = sut.Add(timeSpan);
                 Assert.Equal(expected.Ticks, actual.Ticks);
             }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeLessThanMinimum() {
+                var timeSpan = -new TimeSpan(inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut.Add(timeSpan));
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeGreaterThanMaximum() {
+                var timeSpan = new TimeSpan(DateTime.MaxValue.Ticks - inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut.Add(timeSpan));
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
         }
 
         public class AdditionOperator: UtcDateTimeTest
@@ -190,6 +204,20 @@ namespace Chronology
                 DateTime expected = inputDateTime + timeSpan;
                 UtcDateTime actual = sut + timeSpan;
                 Assert.Equal(expected.Ticks, actual.Ticks);
+            }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeLessThanMinimum() {
+                var timeSpan = -new TimeSpan(inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut + timeSpan);
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeGreaterThanMaximum() {
+                var timeSpan = new TimeSpan(DateTime.MaxValue.Ticks - inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut + timeSpan);
+                Assert.Equal("timeSpan", thrown.ParamName);
             }
         }
 
@@ -354,7 +382,7 @@ namespace Chronology
             }
         }
 
-        public class Subtract: UtcDateTimeTest
+        public class SubtractTimeSpan: UtcDateTimeTest
         {
             [Fact]
             public void SubtractsTimeSpanFromUtcDateTime() {
@@ -365,6 +393,23 @@ namespace Chronology
             }
 
             [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeLessThanMinimum() {
+                var timeSpan = new TimeSpan(inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut.Subtract(timeSpan));
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeGreaterThanMaximum() {
+                var timeSpan = -new TimeSpan(DateTime.MaxValue.Ticks - inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut.Subtract(timeSpan));
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
+        }
+
+        public class SubtractUtcDateTime: UtcDateTimeTest
+        {
+            [Fact]
             public void SubtractsUtcDateTimeAndReturnsTimeSpan() {
                 DateTime other = fuzzy.DateTime(DateTimeKind.Utc);
                 TimeSpan expected = inputDateTime - other;
@@ -373,7 +418,7 @@ namespace Chronology
             }
         }
 
-        public class SubtractionOperator: UtcDateTimeTest
+        public class SubtractTimeSpanOperator: UtcDateTimeTest
         {
             [Fact]
             public void SubtractsTimeSpanFromUtcDateTime() {
@@ -383,6 +428,23 @@ namespace Chronology
                 Assert.Equal(expected.Ticks, actual.Ticks);
             }
 
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeLessThanMinimum() {
+                var timeSpan = new TimeSpan(inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut - timeSpan);
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
+
+            [Fact]
+            public void ThrowsArgumentOutOfRangeExceptionWhenResultWouldBeGreaterThanMaximum() {
+                var timeSpan = -new TimeSpan(DateTime.MaxValue.Ticks - inputDateTime.Ticks + 1);
+                var thrown = Assert.Throws<ArgumentOutOfRangeException>(() => sut - timeSpan);
+                Assert.Equal("timeSpan", thrown.ParamName);
+            }
+        }
+
+        public class SubtractUtcDateTimeOperator: UtcDateTimeTest
+        {
             [Fact]
             public void SubtractsUtcDateTimeAndReturnsTimeSpan() {
                 DateTime other = fuzzy.DateTime(DateTimeKind.Utc);


### PR DESCRIPTION
Make `UtcDateTime` store `long` ticks value instead of `DateTime` to eliminate `DateTimeKind.Unspecified`.